### PR TITLE
Results from tuning the drone

### DIFF
--- a/src/main/fc/fc_tasks.c
+++ b/src/main/fc/fc_tasks.c
@@ -83,7 +83,7 @@ cfTask_t cfTasks[] = {
     [TASK_SERIAL] = {
         .taskName = "SERIAL",
         .taskFunc = taskHandleSerial,
-        .desiredPeriod = TASK_PERIOD_HZ(100),         // 100 Hz should be enough to flush up to 115 bytes @ 115200 baud
+        .desiredPeriod = TASK_PERIOD_HZ(1000),         // 100 Hz should be enough to flush up to 115 bytes @ 115200 baud
         .staticPriority = TASK_PRIORITY_LOW,
     },
 

--- a/src/main/fc/msp_server_fc.c
+++ b/src/main/fc/msp_server_fc.c
@@ -587,10 +587,11 @@ int mspServerCommandHandler(mspPacket_t *cmd, mspPacket_t *reply)
 
         case MSP_RAW_IMU: {
             // Hack scale due to choice of units for sensor data in multiwii
-            unsigned scale_shift = (acc.acc_1G > 1024) ? 3 : 0;
+            //unsigned scale_shift = (acc.acc_1G > 1024) ? 3 : 0;
 
             for (unsigned i = 0; i < 3; i++)
-                sbufWriteU16(dst, accSmooth[i] >> scale_shift);
+                //sbufWriteU16(dst, accSmooth[i] >> scale_shift);
+                sbufWriteU16(dst, accSmooth[i]);
             for (unsigned i = 0; i < 3; i++)
                 sbufWriteU16(dst, gyroADC[i]);
             for (unsigned i = 0; i < 3; i++)

--- a/src/main/rx/msp.c
+++ b/src/main/rx/msp.c
@@ -64,8 +64,11 @@ void rxMspChannelsReset()
     // Also clear MSP channels to make sure old data doesn't sneak in
     mspFrame[ROLL]  = 1500;
     mspFrame[PITCH]  = 1500;
-    mspFrame[YAW]  = 1500;
-    mspFrame[THROTTLE] = 1000;
+
+    // It was found through testing that THROTTLE was actually YAW and YAW was THROTTLE
+    // It appears that items in these arrays aren't in the same order as in rx.c
+    mspFrame[THROTTLE]  = 1500;
+    mspFrame[YAW] = 1000;
     for(uint8_t channel = AUX1; channel < MAX_SUPPORTED_RC_CHANNEL_COUNT; channel++)
     {
         mspFrame[channel] = 1000;

--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -549,9 +549,9 @@ static void readRxChannelsApplyRanges(void)
     if(autopilot_arm_sequence_state == 2)
     {
         // allow RC override if control sticks are moved
-        rcRaw[ROLL]  = (abs(RC_channels[ROLL] - 1500) < 50) ? MSP_channels[ROLL] : RC_channels[ROLL];
-        rcRaw[PITCH]  = (abs(RC_channels[PITCH] - 1500) < 50) ? MSP_channels[PITCH] : RC_channels[PITCH];
-        rcRaw[YAW]  = (abs(RC_channels[YAW] - 1500) < 50) ? MSP_channels[YAW] : RC_channels[YAW];
+        rcRaw[ROLL]  = (abs(RC_channels[ROLL] - 1500) < 10) ? MSP_channels[ROLL] : RC_channels[ROLL];
+        rcRaw[PITCH]  = (abs(RC_channels[PITCH] - 1500) < 10) ? MSP_channels[PITCH] : RC_channels[PITCH];
+        rcRaw[YAW]  = (abs(RC_channels[YAW] - 1500) < 10) ? MSP_channels[YAW] : RC_channels[YAW];
 
         // saturate thrust at RC value even when accepting MSP commands. This allows the throttle to be cut easily.
         throttle_jump_possible = true;


### PR DESCRIPTION
Deadzone for sticks is reduced.
THROTTLE and YAW were swapped for resetting the MSP buffer.
MSP packet rate was increased from 100Hz to 1000Hz.
MSP_RAW_IMU command does not apply scaling factor upon output of accelerations. The way it did it involved bitshifting to the right which caused loss of bits. We can perform the scaling on the Jetson without losing precision.